### PR TITLE
3D Sphere Uniform Distribution.  WIP Haversine RGG

### DIFF
--- a/TorusRandomGeometricGraph/TorusRandomGeometricGraph.py
+++ b/TorusRandomGeometricGraph/TorusRandomGeometricGraph.py
@@ -1,6 +1,6 @@
 #Written by Nicholas Thevenin for NEU Math REU 2021
 #TODO:
-#add progress tracker
+#add progress tracker to see how many trials are left during operation
 
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -10,11 +10,61 @@ from itertools import accumulate, combinations, product
 from math import sqrt
 import numpy as np
 import math
+import random
+from math import radians, cos, sin, asin, sqrt
+
+
+#WORKING IN RADIANS
+
+def haversine(a, b):
+    lon1, lat1 = a
+    lon2, lat2 = b
+    # haversine formula 
+    dlon = lon2 - lon1 
+    dlat = lat2 - lat1 
+    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    c = 2 * asin(sqrt(a)) 
+    r = 1 # Radius of unit sphere
+    return c * r
+
+def _3D_sphere_edges(G, radius):
+    """Returns edge list of node pairs within `radius` of each other
+       using haversine function
+
+    Works without scipy, but in `O(n^2)` time.
+    """
+    # TODO This can be parallelized.
+    edges = []
+    for (u, pu), (v, pv) in combinations(G.nodes(data="pos"), 2):
+        for a, b in zip(pu, pv)):
+            if (haversine(a,b)) <= radius:
+                edges.append((u, v))
+                print(u,v)
+    return edges
+
 
 
 #Number of dimensions and number of vertices
 d=2
-n=10000
+n=10000 
+radius = 3
+
+random.seed()
+
+G = nx.Graph()
+G.add_nodes_from(range(n))
+
+#STUFF TO GENERATE POINTS ON A SPHERE (gives pairs of spherical coordinates).
+#latitude is in range of -pi/2 to pi/2, because this is what haversine formula expects
+pos = {v: [2* math.pi * random.random(), ((math.acos(1-(2*random.random())))-(math.pi/2))] for v in range(n)}
+
+
+nx.set_node_attributes(G, pos, "pos")
+
+
+
+edges = _3D_sphere_edges(G, radius)
+G.add_edges_from(edges)
 
 
 #Initialize variables which will change often during loops to 0
@@ -23,8 +73,8 @@ counter = 0
 
 
 #Initialize values for statistical paremeters, number of trials, and number of radii tested
-trials = 100
-categories = 10
+trials = 1
+categories = 1
 radius_stop_value=0.05
 
 


### PR DESCRIPTION
I'm misunderstanding how the original authors set up their loop in _slow_edges; untangling the loops in _3D_sphere_edges should be the last thing needed for spherical RGG to be created using l_2 norm.  I hope you can see what I'm going for here, I want it to call the haversine function on each pair of coordinates, then compare to radius and save the edge if true.  pos is a dictionary of all the coordinates